### PR TITLE
Update object_detector.py

### DIFF
--- a/object_detector.py
+++ b/object_detector.py
@@ -74,7 +74,7 @@ def run_model(input):
     :param input: Numpy array in a shape (3,width,height)
     :return: Raw output of YOLOv8 network as an array of shape (1,84,8400)
     """
-    model = ort.InferenceSession("yolov8m.onnx")
+    model = ort.InferenceSession("yolov8m.onnx", providers=['CPUExecutionProvider'])
     outputs = model.run(["output0"], {"images":input})
     return outputs[0]
 


### PR DESCRIPTION
requirements.txt did not specify versions.  With the current version of onnxruntime there is an error in loading ort.InferenceSession when the providers are not included in the call.  I've added providers=['CPUExecutionProvider'] to line 77 which resolved this issue when run on my local machine.